### PR TITLE
이메일, 패스워드 로그인 API 구현

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 """
 
 from pathlib import Path
+from datetime import timedelta
 
 import os
 import environ
@@ -31,6 +32,7 @@ DJANGO_APPS = [
 
 DEPENDENCIES = [
     "rest_framework",
+    "rest_framework_simplejwt",
 ]
 
 INSTALLED_APPS = [
@@ -96,6 +98,15 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': [
         'utils.custom_renderers.CustomBaseRenderer'  
     ],
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+    ],
+}
+
+# JWT
+SIMPLE_JWT = {
+    'ACCESS_TOKEN_LIFETIME': timedelta(hours=2),
+    'REFRESH_TOKEN_LIFETIME': timedelta(days=14),
 }
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,9 +5,11 @@ Django==4.1.5
 django-environ==0.9.0
 django-ses==3.3.0
 djangorestframework==3.14.0
+djangorestframework-simplejwt==5.2.2
 gunicorn==20.1.0
 jmespath==1.0.1
 mysqlclient==2.1.1
+PyJWT==2.6.0
 python-dateutil==2.8.2
 pytz==2022.7.1
 s3transfer==0.6.0

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -39,5 +39,28 @@ class User(AbstractBaseUser):
     deleted_at = models.DateTimeField(null=True)
     
     USERNAME_FIELD = 'email'
+    POSITIVE_REQUIRED_FIELD_TO_LOGIN = (is_active, )
+    NEGATIVE_REQUIRED_FIELDS_TO_LOGIN = (deleted_at, )
     
     objects = UserManager()
+    
+    def check_positive_required_fields(self):
+        for field in self.POSITIVE_REQUIRED_FIELD_TO_LOGIN:
+            value = getattr(self, field.name)
+            if value is None or not value:
+                return False
+        return True
+    
+    def check_negative_required_fields(self):
+        for field in self.NEGATIVE_REQUIRED_FIELDS_TO_LOGIN:
+            value = getattr(self, field.name)
+            if value:
+                return False
+        return True
+    
+    def is_loginnable_user(self):
+        if (self.check_positive_required_fields() 
+            and self.check_negative_required_fields()):
+            return True
+        return False
+            

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -14,6 +14,7 @@ class UserManager(BaseUserManager):
         if not password:
             raise ValueError('비밀번호는 필수 입력 사항입니다.')
         user = self.model(email=self.normalize_email(email), nickname=nickname)
+        user.is_active = True                       ## 현재 이메일 서버 오류로 신규 가입자 모두 활성화 -> 환경 설정 후 삭제
         user.set_password(password)
         user.save()
         return user

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework.validators import UniqueValidator
 
 from utils.custom_fields import PasswordField
+from utils.custom_validators import PasswordValidator
 
 
 class UserBaseSerializer(serializers.ModelSerializer):
@@ -36,3 +37,12 @@ class UserInfoCheckSerializer(serializers.Serializer):
             if field in attrs:
                 return {field: attrs[field]}
         raise serializers.ValidationError("email 혹은 nickname이 반드시 입력되어야 합니다.")    
+
+
+class UserLoginSerializer(serializers.Serializer):
+    email = serializers.EmailField(required=True, write_only=True)
+    password = serializers.CharField(required=True, write_only=True, validators=[PasswordValidator(),])
+    
+    def is_logginable(self, user):
+        return user.is_loginnable_user()
+    

--- a/backend/users/serializers.py
+++ b/backend/users/serializers.py
@@ -6,6 +6,7 @@ from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 from utils.custom_fields import PasswordField
 from utils.custom_validators import PasswordValidator
+from utils.custom_exceptions import UnactivatedUserDenied
 
 
 class UserBaseSerializer(serializers.ModelSerializer):
@@ -61,3 +62,21 @@ class UserLoginSerializer(serializers.Serializer):
             attrs['token'] = TokenObtainPairSerializer.get_token(user)
         
         return attrs
+    
+    def to_representation(self, data):
+        user = data.get('user', None)
+        refresh_token = data.get('token', None)
+
+        if user and refresh_token:
+            return {
+                "data": {
+                    'email': user.email,
+                    'nickname': user.nickname
+                },
+                'token': {
+                    'aceess': str(refresh_token.access_token),
+                    'refresh': str(refresh_token)   
+                }
+            }
+            
+        raise UnactivatedUserDenied()

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('', UserListView.as_view()),
     path('activate/<str:uidb64>/<str:token>/', UserActivateView.as_view()),
     path('user-info-check/', UserInfoCheckView.as_view(), name="user-info-check"),
+    path('login/', UserLoginView.as_view(), name="login"),
 ]

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -63,3 +63,15 @@ class UserInfoCheckView(views.APIView):
             response_data.response,
             status = status.HTTP_200_OK
         )
+
+
+class UserLoginView(views.APIView):
+    
+    def post(self, request):
+        serializer = UserLoginSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return Response(
+            serializer.data,
+            status = status.HTTP_200_OK
+        )
+        

--- a/backend/utils/custom_exceptions.py
+++ b/backend/utils/custom_exceptions.py
@@ -1,0 +1,8 @@
+from django.utils.translation import gettext_lazy as _
+from rest_framework import exceptions
+
+
+class UnactivatedUserDenied(exceptions.PermissionDenied):
+    default_detail = _('활성화되지 않은 사용자입니다.')
+    default_code = "unactivated_user"
+    


### PR DESCRIPTION
## Summary
이메일, 비밀번호를 사용한 사용자 검증 후, 토큰을 발급하여 반환하는 API 구현

## Key Changes
- UnactivatedUserDenied 예외 : 비활성화 사용자의 로그인 시도
- UserLoginSerializer : 사용자 정보의 유효성, 일치하는 사용자 여부, 사용자의 활성화 여부를 판단하여 응답 생성
- UserLoginView : 사용자의 입력 정보를 serializer로 검증 및 응답 반환하는 View


## Related Issue
#16 #7